### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Goots is Google's default TypeScript configuration. Made with ❤️ by the Goog
 - All sources are written in TypeScript
 - All sources go in `src`
 - All tests go in `test`
+- `require('goots/gulpfile)` in your gulpfile.js to inherit the default gulp tasks.
 
 # Tasks
-Run `goots <task>` to try the following pre-built tasks.
+Run `gulp <task>` to try the following pre-built tasks.
 
 - `clean` - deletes the compiled output directory
 - `compile` - runs the TypeScript compiler


### PR DESCRIPTION
* Provide an example on how to require/extend the gulpfile.
* Downplay the `goots` executable. We can still keep it for future uses, but using gulp directly in the child projects is better.

 